### PR TITLE
Перенёс настройки данных в конец узла yAxis: теперь они могут переопределить labels и title

### DIFF
--- a/templates/charts/action_usual.html
+++ b/templates/charts/action_usual.html
@@ -123,7 +123,6 @@ $(function () {
                 yAxis: [
                 [#begin PROPERTIES#]
                 { 
-                                [#if SETTINGS!=""#][#SETTINGS#],[#endif#]
             labels: {
                 format: '{value} [#UNIT#]',
                 style: {
@@ -136,6 +135,7 @@ $(function () {
                     color: Highcharts.getOptions().colors[[#NUM#]]
                 }
             }
+            [#if SETTINGS!=""#],[#SETTINGS#][#endif#]
             [#if OPPOSITE="1"#], opposite: true[#endif#]
         }[#if LAST!="1"#], [#endif#]
                 [#end PROPERTIES#]
@@ -144,7 +144,6 @@ $(function () {
                 yAxis: [
                 [#begin PROPERTIES#]
                 { 
-                                [#if SETTINGS!=""#][#SETTINGS#],[#endif#]
             labels: {
                 format: '{value} [#UNIT#]',
                 style: {
@@ -157,6 +156,7 @@ $(function () {
                     color: Highcharts.getOptions().colors[[#NUM#]]
                 }
             }
+            [#if SETTINGS!=""#],[#SETTINGS#][#endif#]
             [#if OPPOSITE="1"#], opposite: true[#endif#]
         }[#if LAST!="1"#], [#endif#]
                 [#end PROPERTIES#]


### PR DESCRIPTION
Теперь можно определить настройки данных, например, таким образом:
```
labels:{
 formatter: function(){return (this.value/10000) + ' kW';}
}
```
что позволяет переопределить значения по-умолчанию от плагина. В итоге в конфиг Highcharts поступает невалидный json (с двумя узлами labels), однако js прощает такие огрехи и использует последний узел. 

Пример генерации:
```
yAxis: [
    {
        labels: {
            format: '{value} x 0,1 W',
            style: {
                color: Highcharts.getOptions().colors[0]
            }
        },
        title: {
            text: '',
            style: {
                color: Highcharts.getOptions().colors[0]
            }
        },
        labels: {
            formatter: function () {
                return (this.value / 10000) + ' kW';
            }
        }

    }

]

```
здесь первый 'labels' и 'title'  - сгенерированы плагином, а второй 'labels' - из настроек данных (там же может быть переопределен и title и всякое разное отсюда: https://api.highcharts.com/highcharts/yAxis )